### PR TITLE
fix(coreml): w/a fallback to EnableOnSubgraphs=0 on exception

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.23.0" />
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'false'">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.23.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.23.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Analysis\Crepe\Resources.Designer.cs">

--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ML.OnnxRuntime;
 using OpenUtau.Core.Util;
+using Serilog;
 
 namespace OpenUtau.Core {
     public class GpuInfo {
@@ -83,7 +84,7 @@ namespace OpenUtau.Core {
             return gpuList;
         }
 
-        private static SessionOptions getOnnxSessionOptions(){
+        private static SessionOptions getOnnxSessionOptions(bool coremlEnableOnSubgraphs = false) {
             SessionOptions options = new SessionOptions();
             List<string> runnerOptions = getRunnerOptions();
             string runner = Preferences.Default.OnnxRunner;
@@ -103,7 +104,13 @@ namespace OpenUtau.Core {
                      );
                     break;
                 case "CoreML":
-                    options.AppendExecutionProvider_CoreML(CoreMLFlags.COREML_FLAG_ENABLE_ON_SUBGRAPH);
+                    // Note: MLProgram format has stricter validation and may fail with complex DiffSinger models
+                    // that have topological sorting issues (e.g., variance_predictor with diffusion embeddings)
+                    // so we always use NeuralNetwork format (default) as MLProgram fails with complex models.
+                    options.AppendExecutionProvider("CoreML", new Dictionary<string, string> {
+                        { "MLComputeUnits", "ALL" },
+                        { "EnableOnSubgraphs", coremlEnableOnSubgraphs ? "1" : "0" }  // Disable subgraph processing to avoid complex control flow issues
+                    });
                     break;
                 case "NNAPI":
                     options.AppendExecutionProvider_Nnapi();
@@ -116,6 +123,14 @@ namespace OpenUtau.Core {
             if (force_cpu) {
                 return new InferenceSession(model);
             } else {
+                // Try with CoreML subgraphs enabled first, fallback to default if it fails
+                if (OS.IsMacOS() && Preferences.Default.OnnxRunner == "CoreML") {
+                    try {
+                        return new InferenceSession(model, getOnnxSessionOptions(coremlEnableOnSubgraphs: true));
+                    } catch (Exception e) {
+                        Log.Warning(e, "Failed to create session with CoreML subgraphs enabled, falling back to default settings");
+                    }
+                }
                 return new InferenceSession(model, getOnnxSessionOptions());
             }
         }
@@ -124,6 +139,14 @@ namespace OpenUtau.Core {
             if (force_cpu) {
                 return new InferenceSession(modelPath);
             } else {
+                // Try with CoreML subgraphs enabled first, fallback to default if it fails
+                if (OS.IsMacOS() && Preferences.Default.OnnxRunner == "CoreML") {
+                    try {
+                        return new InferenceSession(modelPath, getOnnxSessionOptions(coremlEnableOnSubgraphs: true));
+                    } catch (Exception e) {
+                        Log.Warning(e, "Failed to create session with CoreML subgraphs enabled, falling back to default settings");
+                    }
+                }
                 return new InferenceSession(modelPath, getOnnxSessionOptions());
             }
         }


### PR DESCRIPTION
to eliminate the error:
Microsoft.ML.OnnxRuntime.OnnxRuntimeException: [ErrorCode:Fail] Error compiling model: compiler error: Error reading protobuf spec. validator error: Layer '/variance_predictor/velocity_fn/input_projection/Add' consumes an input named 'variance_predictor.velocity_fn.input_projection.bias' which is not present in this network.